### PR TITLE
gotta unlist the data.frame to test against its contents

### DIFF
--- a/MEPS/R/read_MEPS.R
+++ b/MEPS/R/read_MEPS.R
@@ -61,7 +61,7 @@ read_MEPS <- function(file, year, type, dir, web) {
     # If file is specified, but 'get_puf_names' hasn't been updated,
     # set year to max year in 'get_puf_names'
     pnames <- get_puf_names()
-    if(file %in% pnames) {
+    if(file %in% unlist(pnames)) {
       year_row <- which(pnames == file, arr.ind = T)[1,1]
       year <- pnames$YEAR[year_row]
     } else {


### PR DESCRIPTION
This was always defaulting to the max year, which you normally wouldn't notice, because .dat or .ssp should work fine. I only found out because of the error in parsing the 2002 FYC dat file. I didn't understand why it wasn't using the ssp.