### PR TITLE
specify the stata-style '.' as valid NA character

### DIFF
--- a/MEPS/R/read_MEPS.R
+++ b/MEPS/R/read_MEPS.R
@@ -144,7 +144,8 @@ read_MEPS <- function(file, year, type, dir, web) {
             start = dat_info[["start"]],
             end   = dat_info[["end"]],
             col_names = dat_info[["names"]]),
-        col_types = dat_info[["types"]])
+        col_types = dat_info[["types"]],
+        na=c("","NA","."))
     }
 
   }


### PR DESCRIPTION
This should Close #3 

After making this update:

```
> df <- read_MEPS(file="h70.dat")
trying URL 'https://meps.ahrq.gov/data_files/pufs/h70dat.zip'
Content type 'application/zip' length 12417957 bytes (11.8 MB)
==================================================
downloaded 11.8 MB

> table(df$SFFLAG42)

    0     1 
22936  1313 

> summary(df$SFFLAG42)
   Min. 1st Qu.  Median    Mean 3rd Qu.    Max.    NA's 
  0.000   0.000   0.000   0.054   0.000   1.000   14916 
```

Which matches the online code book as of today:


MEPS H70 CODEBOOK
2002 FULL YEAR CONSOLIDATED FILE
DATE: June 27, 2011


Variable Name: | SFFLAG42
-- | --
Description: | SAQ:PCS/MCS IMPUTATION FLAG SF-12
Format: | 1.0
Type: | NUM
Start: | 2284
End: | 2284


VALUE | UNWEIGHTED | WEIGHTED BY PERWT02F
-- | -- | --
MISSING | 14,916 | 89,874,334
0 NO | 22,936 | 189,396,724
1 YES | 1,313 | 8,910,705
TOTAL | 39,165 | 288,181,763

